### PR TITLE
Read aspectjVersion lazily

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,5 +38,7 @@ gradlePlugin {
 }	
 
 dependencies {
-	compile 'org.codehaus.groovy:groovy-all:2.5.4'
+    implementation 'org.codehaus.groovy:groovy-all:2.5.4'
+
+    testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
  }

--- a/src/main/groovy/aspectj/AspectjGradlePlugin.groovy
+++ b/src/main/groovy/aspectj/AspectjGradlePlugin.groovy
@@ -28,15 +28,12 @@ class AspectjGradlePlugin implements Plugin<Project> {
 	void apply(Project project) {
 		project.plugins.apply(JavaPlugin)
 
-		if (!project.hasProperty('aspectjVersion')) {
-			throw new GradleException("You must set the property 'aspectjVersion' before applying the aspectj plugin")
-		}
-
 		if (project.configurations.findByName('ajtools') == null) {
+			def aspectjVersion = project.objects.property(String).convention(project.provider { project.aspectjVersion })
 			project.configurations.create('ajtools')
 			project.dependencies {
-				ajtools "org.aspectj:aspectjtools:${project.aspectjVersion}"
-				compile "org.aspectj:aspectjrt:${project.aspectjVersion}"
+				ajtools aspectjVersion.map { "org.aspectj:aspectjtools:${it}" }
+				compile aspectjVersion.map { "org.aspectj:aspectjrt:${it}" }
 			}
 		}
 

--- a/src/test/groovy/aspectj/AspectJGradlePluginFuncTest.groovy
+++ b/src/test/groovy/aspectj/AspectJGradlePluginFuncTest.groovy
@@ -1,0 +1,63 @@
+package aspectj
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import java.lang.management.ManagementFactory
+
+class AspectJGradlePluginFuncTest extends Specification {
+
+    @Rule
+    TemporaryFolder projectDir
+
+    def buildFile
+
+    void setup() {
+        buildFile = projectDir.newFile("build.gradle")
+    }
+
+    def "can be applied via plugins block"() {
+        given:
+        buildFile << """
+        plugins {
+            id 'aspectj.AspectjGradlePlugin'
+        }
+        project.ext.aspectjVersion = '1.9.6'
+        """
+
+        expect:
+        success("build")
+    }
+
+    def "fails the build if aspectjVersion is not set as project extension"() {
+        given:
+        buildFile << """
+        plugins {
+            id 'aspectj.AspectjGradlePlugin'
+        }
+        """
+
+        expect:
+        fail("build")
+    }
+
+    def success(String... args) {
+        runner(args).build()
+    }
+
+    def fail(String... args) {
+        runner(args).buildAndFail()
+    }
+
+    private runner(String... args) {
+        GradleRunner.create()
+                .forwardOutput()
+                .withDebug(ManagementFactory.getRuntimeMXBean().getInputArguments().toString().indexOf("-agentlib:jdwp") > 0)
+                .withPluginClasspath()
+                .withArguments([*args, "-s"])
+                .withProjectDir(projectDir.root)
+    }
+}


### PR DESCRIPTION
Instead of eagerly evaluating the aspectjVersion project extension we
now access it lazily using Gradle's provider API. This makes it possible
to apply the plugin via the plugins block but results in a default error
message being displayed in case the aspectjVersion is not present.

Resolves #2