### PR TITLE
fix: Add support for gradle 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 apply plugin: 'groovy'
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 sourceCompatibility = JavaVersion.VERSION_11

--- a/src/main/groovy/aspectj/AspectjGradlePlugin.groovy
+++ b/src/main/groovy/aspectj/AspectjGradlePlugin.groovy
@@ -7,6 +7,7 @@ import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskAction
 
@@ -36,7 +37,7 @@ class AspectjGradlePlugin implements Plugin<Project> {
 				project.configurations.create('ajtools')
 				project.dependencies {
 					ajtools "org.aspectj:aspectjtools:${project.aspectjVersion}"
-					compile "org.aspectj:aspectjrt:${project.aspectjVersion}"
+					implementation "org.aspectj:aspectjrt:${project.aspectjVersion}"
 				}
 			}
 		}
@@ -126,15 +127,21 @@ class AspectjGradlePlugin implements Plugin<Project> {
 
 class Ajc extends DefaultTask {
 
+	@Internal
 	SourceSet sourceSet
 
+	@Internal
 	FileCollection aspectpath
+	@Internal
 	FileCollection ajInpath
 
+	@Internal
 	// ignore or warning
 	String xlint = 'ignore'
 
+	@Internal
 	String maxmem
+	@Internal
 	Map<String, String> additionalAjcArgs
 
 	Ajc() {

--- a/src/test/groovy/aspectj/AspectJGradlePluginFuncTest.groovy
+++ b/src/test/groovy/aspectj/AspectJGradlePluginFuncTest.groovy
@@ -1,6 +1,5 @@
 package aspectj
 
-import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder


### PR DESCRIPTION
Fixes: 

Gradle 7+ has dropped support for `compile`

```
> Could not find method compile() for arguments [org.aspectj:aspectjrt:1.9.7] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.
```

Changes:
- Use `implementation` instead of `compile`
- Specify fields as @Internal